### PR TITLE
README Revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ pass them into the PHP Experiment API override methods after instantiation.
 
 ### Thanks
 
-[PlanOut][], the software from which ABLincoln was ported, is developed and
-maintained by Eytan Bakshy, Dean Eckles, and Michael S. Bernstein. Learn more
+[PlanOut][], the software from which ABLincoln was ported, was originally
+developed by Eytan Bakshy, Dean Eckles, and Michael S. Bernstein, and is
+currently maintained by [Eytan Bakshy][@eytan] at Facebook. Learn more
 about good practice in large-scale testing by reading their paper,
 [Designing and Deploying Online Field Experiments][PlanOut Paper].
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@
 
 ABLincoln is a PHP-based toolkit for online field experimentation, ported from
 Facebook's [PlanOut][] software and released as an easily extendable
-[Composer][] package. ABLincoln makes it easy to deploy and maintain
-sophisticated randomized experiments and to quickly iterate on these
+[Composer][installation] package. ABLincoln makes it easy to deploy and
+maintain sophisticated randomized experiments and to quickly iterate on these
 experiments, while satisfying the constraints of large-scale Internet services
-with many users using a native API that fully integrates with the standard PHP
-stack.
+with many users.
 
 [PlanOut]: http://facebook.github.io/planout/
-[Composer]: #installation
+[installation]: #installation
 
 Developers integrate ABLincoln by defining experiments that detail how _inputs_
 (e.g. users, cookie IDs) should get mapped onto conditions. To set up an
@@ -47,7 +46,7 @@ class MyExperiment extends SimpleExperiment
 Then, in the application code, you query the Experiment object to find out what
 values the current user should be mapped onto:
 
-```
+```php
 $my_exp = new MyExperiment(['userid' => 42]);
 $my_exp->get('button_color');
 $my_exp->get('button_text');
@@ -64,7 +63,7 @@ The basic `SimpleExperiment` class logs to a local file by default. More
 advanced behavior, such as Vimeo's methodology [described below][logging], can
 easily be introduced to better integrate with your existing logging stack.
 
-[logging]: LINK_GOES_HERE
+[logging]: #application-to-an-existing-logging-stack
 
 ### Comparison with Python Release
 
@@ -87,7 +86,43 @@ Notable differences between the two releases currently include:
 ABLincoln was ported and designed with scalability in mind. Here are a few ways
 that Vimeo has chosen to extend it to meet the needs of our testing process:
 
-#### URL Overrides
+##### Serialized Experiments
+
+From the beginning, Vimeo's goal was to develop a software package that would
+simplify the process of creating and running experiments for everyone, even
+those who seldom find themselves writing code. We store all data relating to
+currently running tests - experiment/namespace names, publish/stop dates,
+bucket proportions, parameter names and values, and random operator weighting,
+to name a few - in a SQL database populated by a simple yet comprehensive
+mod panel that allows even the programming illiterate to quickly design
+experiments to launch on the site. Another class handles the process of loading
+experiment information from the database and recreating the test before
+parameter querying.
+
+The consequence of this is that a simple
+`ABLincoln::load('namespace')->get('parameter')` within our stack is all that
+is needed to recreate a given experiment set and query a parameter value from
+the test.
+
+We hope to make experiment serialization even more accessible than it
+currently is with a future implementation of an interpreter for the
+[PlanOut language][].
+
+##### Application to an Existing Logging Stack
+
+TODO
+
+##### Traffic Segmentation
+
+What if you want to deploy a test comparing users from a specific location or
+demographic to the overall population? Vimeo refers to this process as traffic
+"segmentation", and found it easy to implement on top of existing PlanOut code.
+We simply extend the Experiment class and overwrote its `get()` method - if a
+user is bucketed to the experiment but does not belong to the isolated
+demographic, he or she receives a default parameter value instead of the
+test value.
+
+##### URL Overrides
 
 ABLincoln already supports [parameter overrides][] for quickly examining the
 effects of difficult-to-test experiments. A simple way to integrate this
@@ -98,16 +133,10 @@ parameter:
 http://my.site/home.php?overrides=button_color:green,button_text:hello
 ```
 
-Then it's a relatively simple task to read the overrides from the query and
+Then it's a relatively simple task to parse the overrides from the query and
 pass them into the PHP Experiment API override methods after instantiation.
 
 [parameter overrides]: http://facebook.github.io/planout/docs/testing.html
-
-#### Traffic Segmentation
-
-#### Application to an Existing Logging Stack
-
-#### Serialized Experiments
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -8,83 +8,24 @@
 ABLincoln is a PHP-based toolkit for online field experimentation, ported from
 Facebook's [PlanOut][] software and released as an easily extendable
 [Composer][] package. ABLincoln makes it easy to deploy and maintain
-sophisticated experiments and to quickly iterate on these experiments, while
-satisfying the constraints of large-scale Internet services with many users.
+sophisticated randomized experiments and to quickly iterate on these
+experiments, while satisfying the constraints of large-scale Internet services
+with many users using a native API that fully integrates with the standard PHP
+stack.
 
 [PlanOut]: http://facebook.github.io/planout/
-[Composer]: https://getcomposer.org/
+[Composer]: #installation
 
 Developers integrate ABLincoln by defining experiments that detail how _inputs_
-(e.g. users, cookie IDs) should get mapped onto conditions. For example, to
-set up an experiment randomizing both the color and text of a button, you would
-create a class like this:
-
-```php
-class MyExperiment extends SimpleExperiment
-{
-    public function assign($params, $inputs)
-    {
-        $params->button_color = new UniformChoice(
-            ['choices' => ['a', 'b']],
-            $inputs
-        );
-        $params->button_text = new UniformChoice(
-            ['choices' => ['I voted', 'I am a voter']],
-            $inputs
-        );
-    }
-}
-```
-
-Then, in the application code, you query the Experiment object to find what
-values the current user should be mapped onto:
-
-```php
-$my_exp = new MyExperiment(['userid' => 101]);
-$my_exp->get('button_color');
-$my_exp->get('button_text');
-```
-
-ABLincoln takes care of randomizing each `userid` into the right bucket. It
-does so by hashing the input, so each `userid` will always map onto the same
-values for that experiment.
-
-This release currently includes:
-  - An extendable PHP class for defining experiments. This toolkit comes
-  with objects that make it easy to implement randomized assignments while
-  consistently formatting and logging key data.
-  - An extendable class for managing multiple mutually exclusive experiment
-  namespaces to facilitate the deployment of iterative tests.
-  - Native support for any [PSR-3 compliant logger][PSR logger].
-  Developers can either utilize existing PSR loggers such as [Monolog][] or
-  write their own simple adapters to make existing logging stacks PSR-3
-  compliant.
-
-[PSR logger]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
-[Monolog]: https://github.com/Seldaek/monolog
-
-### Who is ABLincoln for?
-
-This software release is a PHP implementation of Facebook's PlanOut code
-designed for researchers, students, and small businesses wanting to run
-experiments. It is designed to be extensible, so that it may be adapted for use
-with large production environments. The implementation here serves as a basis
-for Vimeo's A/B Testing environment used to deploy experiments to hundreds of
-millions of users each month.
-
-### Full Example
-
-To create a basic ABLincoln experiment, you subclass the SimpleExperiment
-object and implement an assignment method. You can use ABLincoln's random
-assignment operators by setting `$params->$varname`, where `$params` is the
-first argument passed to the `assign()` method and `$varname` is the name of
-the variable you are setting.
+(e.g. users, cookie IDs) should get mapped onto conditions. To set up an
+experiment randomizing both the text and color of a button, you would create a
+class like this:
 
 ```php
 use \Vimeo\ABLincoln\Experiments\SimpleExperiment;
 use \Vimeo\ABLincoln\Operators\Random as Random;
 
-class FirstExperiment extends SimpleExperiment
+class MyExperiment extends SimpleExperiment
 {
     public function assign($params, $inputs)
     {
@@ -100,42 +41,79 @@ class FirstExperiment extends SimpleExperiment
             $inputs
         );
     }
-
-    protected function _log($data)
-    {
-        echo json_encode($data);
-    }
 }
-
-$my_exp = new FirstExperiment(['userid' => 12]);
-echo $my_exp->get('button_text') . ' ' . $my_exp->get('button_color');
 ```
 
-The `_log()` method is run every time experiment parameters are queried to
-generate an appropriate exposure log. By default, the method exposure logs
-according to the object's corresponding PSR-logger. For demonstration purposes,
-we have overriden the method here and allowed it to simply print a log string
-to the console. Running the above generates the following output, consisting
-of the JSON log and the parameter values we have determined:
+Then, in the application code, you query the Experiment object to find out what
+values the current user should be mapped onto:
 
 ```
-{"name": "FirstExperiment", "time": 1415140890, "salt": "FirstExperiment", "inputs": {"userid": 12}, "params": {"button_color": "#ff0000", "button_text": "Sign up."}, "event": "exposure"}
-
-Sign up. #ff0000
+$my_exp = new MyExperiment(['userid' => 42]);
+$my_exp->get('button_color');
+$my_exp->get('button_text');
 ```
 
-The `SimpleExperiment` class will automatically concatenate the name of the
-experiment, `FirstExperiment`, the variable name, and the input data (`userid`)
-and hash that string to perform the random assignment. Parameter assignments
-and inputs are automatically logged according to the specifications of the PSR
-logger instance provided (or the `_log()` method if overridden).
+Querying the experiment parameters automatically generates an exposure log that
+we can direct to a location of our choice:
+
+```
+{"name": "MyExperiment", "time": 1421622363, "salt": "MyExperiment", "inputs": {"userid": 42}, "params": {"button_color": "#ff0000", "button_text": "Join now!"}, "event": "exposure"}
+```
+
+The basic `SimpleExperiment` class logs to a local file by default. More
+advanced behavior, such as Vimeo's methodology [described below][logging], can
+easily be introduced to better integrate with your existing logging stack.
+
+[logging]: LINK_GOES_HERE
+
+### Comparison with Python Release
+
+ABLincoln and the original Python release of PlanOut are very similar in both
+functionality and usage. Both packages implement abstract and concrete versions
+of the Experiment and Namespace classes, parameter overrides to facilitate
+testing, exposure logging systems, and various random assignment operators
+tested and confirmed to produce identical outputs.
+
+Notable differences between the two releases currently include:
+  - ABLincoln features native support for logging either to local files or
+  to any PSR-compliant stack through the use of included PHP logging traits
+  - ABLincoln does not currently include an interpreter for the
+  [PlanOut language][].
+
+[PlanOut language]: http://facebook.github.io/planout/docs/planout-language.html
+
+### Usage in Production Environments
+
+ABLincoln was ported and designed with scalability in mind. Here are a few ways
+that Vimeo has chosen to extend it to meet the needs of our testing process:
+
+#### URL Overrides
+
+ABLincoln already supports [parameter overrides][] for quickly examining the
+effects of difficult-to-test experiments. A simple way to integrate this
+behavior with a live site is to pass overrides into your endpoint as a query
+parameter:
+
+```
+http://my.site/home.php?overrides=button_color:green,button_text:hello
+```
+
+Then it's a relatively simple task to read the overrides from the query and
+pass them into the PHP Experiment API override methods after instantiation.
+
+[parameter overrides]: http://facebook.github.io/planout/docs/testing.html
+
+#### Traffic Segmentation
+
+#### Application to an Existing Logging Stack
+
+#### Serialized Experiments
 
 ### Installation
 
 ABLincoln is maintained as an independent PHP [Composer][] package hosted on
-[Packagist][]. While you can download the source code directly from this
-repository, we recommend including it as a project dependency in your
-`composer.json` file instead:
+[Packagist][]. Include it in in your `composer.json` file for nice autoloading
+and dependency management:
 
 ```
 {
@@ -146,7 +124,7 @@ repository, we recommend including it as a project dependency in your
 ```
 
 [Composer]: https://getcomposer.org/
-[Packagist]: https://packagist.org/
+[Packagist]: https://packagist.org/packages/vimeo/ablincoln
 
 ### Thanks
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,19 @@ currently is with a future implementation of an interpreter for the
 
 ##### Application to an Existing Logging Stack
 
-TODO
+The Experiment [logging traits][] provided with this port make it easy to log
+exposure data in the most convenient way possible for your existing stack. A
+quick implementation of the plug-and-play [FileLoggerTrait][] and a simple
+`tail -f` of the log file is all you need to monitor parameter exposures in
+real-time. Alternatively, the [PSRLoggerTrait][] allows more customizable
+integration with existing PSR-compliant logging code. Here at Vimeo, we use
+a basic [Monolog Handler][] to enforce PSR-3 compliance and allow PlanOut to
+talk nicely to our existing logging infrastructure.
+
+[logging traits]: https://github.com/vimeo/ABLincoln/tree/master/src/Vimeo/ABLincoln/Experiments/Logging
+[FileLoggerTrait]: src/Vimeo/ABLincoln/Experiments/Logging/FileLoggerTrait.php
+[PSRLoggerTrait]: src/Vimeo/ABLincoln/Experiments/Logging/PSRLoggerTrait.php
+[Monolog Handler]: https://github.com/Seldaek/monolog
 
 ##### Traffic Segmentation
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ easily be introduced to better integrate with your existing logging stack.
 
 [logging]: #application-to-an-existing-logging-stack
 
+### Installation
+
+ABLincoln is maintained as an independent PHP [Composer][] package hosted on
+[Packagist][]. Include it in in your `composer.json` file for nice autoloading
+and dependency management:
+
+```
+{
+    "require": {
+        "vimeo/ablincoln": "0.1.2"
+    }
+}
+```
+
+[Composer]: https://getcomposer.org/
+[Packagist]: https://packagist.org/packages/vimeo/ablincoln
+
 ### Comparison with Python Release
 
 ABLincoln and the original Python release of PlanOut are very similar in both
@@ -137,23 +154,6 @@ Then it's a relatively simple task to parse the overrides from the query and
 pass them into the PHP Experiment API override methods after instantiation.
 
 [parameter overrides]: http://facebook.github.io/planout/docs/testing.html
-
-### Installation
-
-ABLincoln is maintained as an independent PHP [Composer][] package hosted on
-[Packagist][]. Include it in in your `composer.json` file for nice autoloading
-and dependency management:
-
-```
-{
-    "require": {
-        "vimeo/ablincoln": "0.1.2"
-    }
-}
-```
-
-[Composer]: https://getcomposer.org/
-[Packagist]: https://packagist.org/packages/vimeo/ablincoln
 
 ### Thanks
 

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ currently is with a future implementation of an interpreter for the
 
 The Experiment [logging traits][] provided with this port make it easy to log
 exposure data in the most convenient way possible for your existing stack. A
-quick implementation of the plug-and-play [FileLoggerTrait][] and a simple
-`tail -f` of the log file is all you need to monitor parameter exposures in
-real-time. Alternatively, the [PSRLoggerTrait][] allows more customizable
-integration with existing PSR-compliant logging code. Here at Vimeo, we use
-a basic [Monolog Handler][] to enforce PSR-3 compliance and allow PlanOut to
-talk nicely to our existing logging infrastructure.
+quick implementation of the plug-and-play [FileLoggerTrait][] and`tail -f` of
+the log file is all you need to monitor parameter exposures in real-time.
+Alternatively, the [PSRLoggerTrait][] allows more customizable integration with
+existing PSR-compliant logging code. Here at Vimeo, we use a basic
+[Monolog Handler][] to enforce PSR-3 compliance and allow PlanOut to talk
+nicely to our existing logging infrastructure.
 
 [logging traits]: https://github.com/vimeo/ABLincoln/tree/master/src/Vimeo/ABLincoln/Experiments/Logging
 [FileLoggerTrait]: src/Vimeo/ABLincoln/Experiments/Logging/FileLoggerTrait.php

--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@
 [build image]: https://travis-ci.org/vimeo/ABLincoln.svg?branch=master
 [build link]: https://travis-ci.org/vimeo/ABLincoln
 
-ABLincoln is a PHP-based toolkit for online field experimentation, ported from
-Facebook's [PlanOut][] software and released as an easily extendable
-[Composer][installation] package. ABLincoln makes it easy to deploy and
+ABLincoln is a PHP-based implementation of Facebook's [PlanOut], a framework
+for online field experimentation. ABLincoln makes it easy to deploy and
 maintain sophisticated randomized experiments and to quickly iterate on these
 experiments, while satisfying the constraints of large-scale Internet services
 with many users.
 
 [PlanOut]: http://facebook.github.io/planout/
-[installation]: #installation
 
 Developers integrate ABLincoln by defining experiments that detail how _inputs_
 (e.g. users, cookie IDs) should get mapped onto conditions. To set up an
@@ -82,7 +80,7 @@ and dependency management:
 [Composer]: https://getcomposer.org/
 [Packagist]: https://packagist.org/packages/vimeo/ablincoln
 
-### Comparison with Python Release
+### Comparison with the PlanOut Reference Implementation
 
 ABLincoln and the original Python release of PlanOut are very similar in both
 functionality and usage. Both packages implement abstract and concrete versions
@@ -100,30 +98,9 @@ Notable differences between the two releases currently include:
 
 ### Usage in Production Environments
 
-ABLincoln was ported and designed with scalability in mind. Here are a few ways
-that Vimeo has chosen to extend it to meet the needs of our testing process:
-
-##### Serialized Experiments
-
-From the beginning, Vimeo's goal was to develop a software package that would
-simplify the process of creating and running experiments for everyone, even
-those who seldom find themselves writing code. We store all data relating to
-currently running tests - experiment/namespace names, publish/stop dates,
-bucket proportions, parameter names and values, and random operator weighting,
-to name a few - in a SQL database populated by a simple yet comprehensive
-mod panel that allows even the programming illiterate to quickly design
-experiments to launch on the site. Another class handles the process of loading
-experiment information from the database and recreating the test before
-parameter querying.
-
-The consequence of this is that a simple
-`ABLincoln::load('namespace')->get('parameter')` within our stack is all that
-is needed to recreate a given experiment set and query a parameter value from
-the test.
-
-We hope to make experiment serialization even more accessible than it
-currently is with a future implementation of an interpreter for the
-[PlanOut language][].
+ABLincoln was ported and designed with scalability in mind. Here are a couple
+ways that Vimeo has chosen to extend it to meet the needs of our testing
+process:
 
 ##### Application to an Existing Logging Stack
 
@@ -140,16 +117,6 @@ nicely to our existing logging infrastructure.
 [FileLoggerTrait]: src/Vimeo/ABLincoln/Experiments/Logging/FileLoggerTrait.php
 [PSRLoggerTrait]: src/Vimeo/ABLincoln/Experiments/Logging/PSRLoggerTrait.php
 [Monolog Handler]: https://github.com/Seldaek/monolog
-
-##### Traffic Segmentation
-
-What if you want to deploy a test comparing users from a specific location or
-demographic to the overall population? Vimeo refers to this process as traffic
-"segmentation", and found it easy to implement on top of existing PlanOut code.
-We simply extend the Experiment class and overwrote its `get()` method - if a
-user is bucketed to the experiment but does not belong to the isolated
-demographic, he or she receives a default parameter value instead of the
-test value.
 
 ##### URL Overrides
 


### PR DESCRIPTION
Addresses #6 - rewrote readme to regurgitate less text from the original PlanOut release and focus more on implementation differences + how the package is used at Vimeo. cc @eytan for merge.