### PR TITLE
Fix Variable Defined as Constant

### DIFF
--- a/src/Vimeo/ABLincoln/Experiments/AbstractExperiment.php
+++ b/src/Vimeo/ABLincoln/Experiments/AbstractExperiment.php
@@ -168,7 +168,7 @@ abstract class AbstractExperiment
      */
     public function setExposureLogged($value)
     {
-        $this->exposure_logged = value;
+        $this->exposure_logged = $value;
     }
 
     /**


### PR DESCRIPTION
There were a variable on AbstractExperiment that was missing
the dollar sign and causing PHP to try to interpret it as
a non-existent constant, and finally falling back to a string
which is for sure not the expected behavior, so i am fixing it.